### PR TITLE
Add `--stdin` to diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ aobtool format 7458FCFF03
 ### AOB Diff
 Performs diff between multiple AOBs in a file, 1 AOB per line.
 ```
-$ aobtool diff <aob file> [--wildcard <wildcard character>]
+$ aobtool diff [--file <aob file>] [--wildcard <wildcard character>] [--stdin]
 ```
 
 Example:

--- a/src/AobTool.Cli/CommandHandler.cs
+++ b/src/AobTool.Cli/CommandHandler.cs
@@ -42,4 +42,21 @@ public static class CommandHandler
             current = AobHelper.CompareAob(current, AobHelper.ParseAob(aob), wildcard);
         return string.Join(" ", current);
     }
+
+    /// <summary>
+    /// Reads strings from stdin.
+    /// </summary>
+    /// <returns>The input entered by user.</returns>
+    public static IEnumerable<string> ReadStdin()
+    {
+        var result = new List<string>();
+        var text = Console.ReadLine();
+
+        while (!string.IsNullOrEmpty(text))
+        {
+            result.Add(text);
+            text = Console.ReadLine();
+        }
+        return result;
+    }
 }


### PR DESCRIPTION
Summary:
- Added `--stdin` option to `diff`, which allows reading AOBs from `stdin` instead of a file
- Made `filename` positional argument an optional instead (`--file` or `-f`)
    - If `-f` option is not used, then automatically enable `--stdin`
    - If `-f` and `--stdin` are both enabled, read from file first then read from `stdin`